### PR TITLE
fixed link to match the dir github creates when checkingout project

### DIFF
--- a/Widget.sublime-settings
+++ b/Widget.sublime-settings
@@ -1,5 +1,5 @@
 {
-  "syntax": "Packages/MXUnit/MXUnitConsole.tmLanguage",
-  "color_scheme": "Packages/MXUnit/MXUnitConsole.tmTheme"
+  "syntax": "Packages/sublime-text-2-mxunit/MXUnitConsole.tmLanguage",
+  "color_scheme": "Packages/sublime-text-2-mxunit/MXUnitConsole.tmTheme"
 }
   


### PR DESCRIPTION
the widget.sublime-settings file looks for the package in the mxunit directory instead of the sublime-text-2-mxunit directory.   
