### PR TITLE
Implement Railo compatibility

### DIFF
--- a/mxunit_plugin.py
+++ b/mxunit_plugin.py
@@ -233,7 +233,15 @@ def pretty_results(test_results, show_failures_only):
 			i=0
 			for var in _debug:
 				print '%s = %s' % ( var, _debug[i] )
-				_results += "		Debug: 	%s \n " %  var['VAR']  
+				if 'var' in var:
+					var_val = var['var']
+				elif 'VAR' in var:
+					var_val = var['VAR']
+				else:
+					var_val = None
+
+				if var_val != None:
+					_results += "		Debug: 	%s \n " % var_val
 
 		if( test['TESTSTATUS'] in ('Failed','Error') ):
 			_results += '		Message: %s\n' % test['ERROR']['Message']


### PR DESCRIPTION
Railo outputs a lowercase 'var' key in its JSON runtestremote.

I have changed mxunit_plugin.py to look for either 'VAR' or 'var' so that it works in either ACF or Railo.
