### PR TITLE
Added support for removing JSON prefix on rest services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,15 @@ __Or (Using mouse clicks)__
 		"port" : "8301" ,
 		"component_root" : "/" ,
 		"web_root" :  "/home/billy/software/jrun4/servers/dev/cfusion.ear/cfusion.war/" ,
+		"json_prefix_regex": "//"
 	
 	}
 	``` 
 	The ```component_root``` is how the web server sees your application. Above assumed all apps are visible from
 	http://localhost:8301/  and all files are stored in the  ```web_root``` directory.
 
+	The ```json_prefix_regex``` is used to remove the JSON prefix of your requests before decoding to JSON object. Use it to fix the "No JSON object could be decoded" error when running tests.
+	To check if you have JSON prefix enabled go to "CFIDE > Server Settings > Settings > Prefix serialized JSON with ...", there you can see if it is enabled and what's the prefix in use.
 
 ## Installation via [Package Control](http://wbond.net/sublime_packages/package_control)
 

--- a/mxunit.settings.example
+++ b/mxunit.settings.example
@@ -11,7 +11,10 @@
 	"server" : "localhost",
 	"port" : "8301" ,
 
+
 	//Make sure to add leading and trailing '/'
 	"component_root" : "/" ,
-	"web_root" :    "/home/billy/software/jrun4/servers/dev/cfusion.ear/cfusion.war"
+	"web_root" :    "/home/billy/software/jrun4/servers/dev/cfusion.ear/cfusion.war",
+
+	"json_prefix_regex": "",
 }

--- a/mxunit_plugin.py
+++ b/mxunit_plugin.py
@@ -30,6 +30,8 @@ class BaseCommand(sublime_plugin.TextCommand):
 
 		self.view = view
 		self.output_view = None
+		self.json_prefix_regex = re.compile('^' + global_settings.get('json_prefix_regex', ''))
+
 		# grab the runner config items
 		self.port = global_settings.get('port', '80')
 		self.server = global_settings.get('server', 'localhost')
@@ -65,6 +67,8 @@ class BaseCommand(sublime_plugin.TextCommand):
 			_res = urlopen(url)
 			self._win = self.view.window()
 			self._results = _res.read()
+			self._results = re.sub(self.json_prefix_regex, '', self._results)
+
 			self.view.window().run_command(
 				"show_panel", {"panel": "output.tests"}
 			)

--- a/mxunit_plugin.py
+++ b/mxunit_plugin.py
@@ -56,13 +56,13 @@ class BaseCommand(sublime_plugin.TextCommand):
 		)
 
 	def on_done(self, selected_item):
-		""" Playing with quick panel events. Does nothing useful."""
+		"""Playing with quick panel events. Does nothing useful."""
 		keys = self.test_items.keys()
 		key = keys[selected_item]
 		print(self.test_items[key])
 
 	def run_test(self, url, edit, show_failures_only=False):
-		""" Main test runner. Intended to be called  from child command."""
+		"""Main test runner. Intended to be called  from child command."""
 		try:
 			_res = urlopen(url)
 			self._win = self.view.window()
@@ -115,36 +115,36 @@ class ShowQpCommand(BaseCommand):
 	"""
 
 	def run(self, edit):
-		""" Run. """
+		"""Run."""
 		self.show_qp()
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class HideTestPanelCommand(BaseCommand):
 
-	""" Hide the test results panel (esc works fine, but whatever...)."""
+	"""Hide the test results panel (esc works fine, but whatever...)."""
 
 	def run(self, edit):
-		""" Run. """
+		"""Run."""
 		self.view.window().run_command("hide_panel", {"panel": "output.tests"})
 
 
 class ShowTestPanelCommand(BaseCommand):
 
-	""" Shows the test results panel. """
+	"""Shows the test results panel."""
 
 	def run(self, edit):
-		""" Run. """
+		"""Run."""
 		self.view.window().run_command("show_panel", {"panel": "output.tests"})
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class MxunitCommand(BaseCommand):
 
-	""" Runs all tests in an MXUnit testcase."""
+	"""Runs all tests in an MXUnit testcase."""
 
 	def run(self, edit):
-		""" Run. """
+		"""Run."""
 		_view = self.view
 		_current_file = self.canonize(_view.file_name())
 		_web_root = self.canonize(get_setting_w_project_override('web_root', self.web_root))
@@ -160,17 +160,17 @@ class MxunitCommand(BaseCommand):
 		self.run_test(_url, edit)
 
 	def canonize(self, path):
-		""" Canonize. """
+		"""Canonize."""
 		return path.replace('\\', '/')
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class RunAllFailuresOnlyCommand(BaseCommand):
 
-	""" Runs all tests in an MXUnit testcase but display only failures. """
+	"""Runs all tests in an MXUnit testcase but display only failures."""
 
 	def run(self, edit):
-		""" Run. """
+		"""Run."""
 		_view = self.view
 		_current_file = _view.file_name()
 		# test
@@ -189,10 +189,10 @@ class RunAllFailuresOnlyCommand(BaseCommand):
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class RunLastTestCommand(BaseCommand):
 
-	""" Looks up the last run test and simly runs it. """
+	"""Looks up the last run test and simly runs it."""
 
 	def run(self, edit):
-		""" Run. """
+		"""Run."""
 		_url = self.last_run_settings.get("last_test_run")
 		_show_failures = self.last_run_settings.get("show_failures_only")
 		self.run_test(_url, edit, _show_failures)
@@ -209,7 +209,7 @@ class SingleTestCommand(BaseCommand):
 	"""
 
 	def run(self, edit):
-		""" Run. """
+		"""Run."""
 		_view = self.view
 		for region in _view.sel():
 			line = _view.line(region)
@@ -293,7 +293,7 @@ def pretty_results(test_results, show_failures_only):
 
 
 def pretty_print_stacktrace(data):
-	""" Pretty print the stacktrace. """
+	"""Pretty print the stacktrace."""
 	results = ''
 	print(len(data[0]))
 	for e in data:
@@ -303,7 +303,7 @@ def pretty_print_stacktrace(data):
 
 
 def parse_line(line):
-	""" From a line of text gets the function name. """
+	"""From a line of text gets the function name."""
 	pattern = re.compile(
 		"""
 		[ \t]*
@@ -320,7 +320,7 @@ def parse_line(line):
 
 
 def get_setting_w_project_override(name, default):
-	""" settings. """
+	"""settings."""
 	project_settings = sublime.active_window().active_view().settings().get('MXUnit')
 	if project_settings is not None:
 		setting = project_settings.get(name, default)


### PR DESCRIPTION
**Problem**: "No JSON object could be decoded" error when running my tests. 

**Cause**: We are using the  _Server Settings > Settings > Prefix serialized JSON with_ option in CFIDE for our app, thus all json output is preceded by "//" which was causing it.

**Solution**:  I added the `json_prefix_regex`` setting, and then I use it to capture and remove the JSON prefix from the response before decoding it to a JSON object. 
